### PR TITLE
fix Upload avatar endpoint

### DIFF
--- a/src/main/java/online/talkandtravel/exception/avatar/UserAvatarNotFoundException.java
+++ b/src/main/java/online/talkandtravel/exception/avatar/UserAvatarNotFoundException.java
@@ -16,7 +16,7 @@ import org.springframework.http.HttpStatus;
  */
 public class UserAvatarNotFoundException extends ApiException {
 
-  private static final String MESSAGE = "User avatar [%s] not found";
+  private static final String MESSAGE = "User avatar with id [%s] not found";
   private static final HttpStatus STATUS = HttpStatus.NOT_FOUND;
 
   public UserAvatarNotFoundException(Long userId) {

--- a/src/main/java/online/talkandtravel/exception/avatar/UserAvatarNotFoundException.java
+++ b/src/main/java/online/talkandtravel/exception/avatar/UserAvatarNotFoundException.java
@@ -1,0 +1,25 @@
+package online.talkandtravel.exception.avatar;
+
+import online.talkandtravel.exception.model.ApiException;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Exception thrown when a specified country is not found.
+ *
+ * <p>This exception is used to indicate that a request involving a specific country cannot be
+ * processed because the country does not exist in the system. It extends {@link ApiException} to
+ * fit within the application's exception handling framework, providing both a detailed message and
+ * an HTTP status code.
+ *
+ * <p>The exception message is formatted with the name of the country that could not be found. The
+ * HTTP status is set to 404 (Not Found) to indicate that the requested resource is missing.
+ */
+public class UserAvatarNotFoundException extends ApiException {
+
+  private static final String MESSAGE = "User avatar [%s] not found";
+  private static final HttpStatus STATUS = HttpStatus.NOT_FOUND;
+
+  public UserAvatarNotFoundException(Long userId) {
+    super(MESSAGE.formatted(userId), STATUS);
+  }
+}

--- a/src/main/java/online/talkandtravel/service/impl/AvatarServiceImpl.java
+++ b/src/main/java/online/talkandtravel/service/impl/AvatarServiceImpl.java
@@ -2,9 +2,9 @@ package online.talkandtravel.service.impl;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import online.talkandtravel.exception.avatar.UserAvatarNotFoundException;
 import online.talkandtravel.exception.file.FileSizeExceededException;
 import online.talkandtravel.exception.file.ImageProcessingException;
 import online.talkandtravel.exception.file.UnsupportedFormatException;
@@ -86,7 +86,7 @@ public class AvatarServiceImpl implements AvatarService {
         repository
             .findByUserId(userId)
             .orElseThrow(
-                () -> new NoSuchElementException("Can not find avatar by user ID: " + userId));
+                () -> new UserAvatarNotFoundException(userId));
     avatar.setContent(avatar.getContent());
     return avatar;
   }

--- a/src/main/java/online/talkandtravel/service/impl/AvatarServiceImpl.java
+++ b/src/main/java/online/talkandtravel/service/impl/AvatarServiceImpl.java
@@ -28,7 +28,7 @@ import org.springframework.web.multipart.MultipartFile;
  *       username.
  *   <li>{@link #uploadAvatar(MultipartFile, Long)} - Uploads and saves a new avatar for a user from
  *       a multipart file.
- *   <li>{@link #getExistingAvatar(Long)} - Retrieves an existing avatar or throws an exception if
+ *   <li>{@link #getAvatar(Long)} - Retrieves an existing avatar or throws an exception if
  *       not found.
  *   <li>{@link #validateImage(MultipartFile, String)} - Validates the format and size of the
  *       uploaded image file.
@@ -60,7 +60,7 @@ public class AvatarServiceImpl implements AvatarService {
   @Override
   @Transactional
   public Avatar findByUserId(Long userId) {
-    return getExistingAvatar(userId);
+    return getAvatar(userId);
   }
 
   @Override
@@ -76,19 +76,9 @@ public class AvatarServiceImpl implements AvatarService {
     byte[] image = extractImageData(file);
     String filename = file.getOriginalFilename();
     validateImage(file, filename);
-    var existingAvatar = getExistingAvatar(userId);
+    var existingAvatar = getAvatar(userId);
     existingAvatar.setContent(image);
     return repository.save(existingAvatar);
-  }
-
-  private Avatar getExistingAvatar(Long userId) {
-    Avatar avatar =
-        repository
-            .findByUserId(userId)
-            .orElseThrow(
-                () -> new UserAvatarNotFoundException(userId));
-    avatar.setContent(avatar.getContent());
-    return avatar;
   }
 
   private void validateImage(MultipartFile imageFile, String originalFilename)
@@ -125,5 +115,12 @@ public class AvatarServiceImpl implements AvatarService {
 
   private Avatar createNewAvatar(byte[] standardAvatar) {
     return Avatar.builder().content(standardAvatar).build();
+  }
+
+
+  private Avatar getAvatar(Long userId) {
+    return repository
+        .findByUserId(userId)
+        .orElseThrow(() -> new UserAvatarNotFoundException(userId));
   }
 }

--- a/src/test/java/online/talkandtravel/service/impl/AvatarServiceImplTest.java
+++ b/src/test/java/online/talkandtravel/service/impl/AvatarServiceImplTest.java
@@ -1,0 +1,66 @@
+package online.talkandtravel.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+import online.talkandtravel.exception.avatar.UserAvatarNotFoundException;
+import online.talkandtravel.model.entity.Avatar;
+import online.talkandtravel.repository.AvatarRepository;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AvatarServiceImplTest {
+
+  @Mock private AvatarRepository avatarRepository;
+
+  @InjectMocks AvatarServiceImpl underTest;
+
+  @Nested
+  class FindById {
+    private final Long userId = 1L;
+    @Test
+    void findByUserId_shouldThrow_whenNoAvatarFound() {
+      when(avatarRepository.findByUserId(userId)).thenReturn(Optional.empty());
+      assertThrows(UserAvatarNotFoundException.class, () -> underTest.findByUserId(userId));
+    }
+
+    @Test()
+    void findByUserId_shouldThrow_whenInvalidID() {
+      when(avatarRepository.findByUserId(userId)).thenThrow(RuntimeException.class);
+      assertThrows(RuntimeException.class, () -> underTest.findByUserId(userId));
+    }
+
+    @ParameterizedTest
+    @MethodSource("verifyExpectedResultArgs")
+    void findByUserId_shouldResultDiffer_whenDifferentArguments(Long userId, Avatar expected) {
+      verifyExpectedResult(userId, expected);
+    }
+
+    private static Stream<Arguments> verifyExpectedResultArgs() {
+      return Stream.of(
+          Arguments.of(1L, Avatar.builder().id(1L).build()),
+          Arguments.of(2L, Avatar.builder().id(2L).build())
+      );
+    }
+
+    private void verifyExpectedResult(Long userId, Avatar expected) {
+      when(avatarRepository.findByUserId(userId)).thenReturn(Optional.ofNullable(expected));
+      Avatar result = underTest.findByUserId(userId);
+      assertEquals(expected, result);
+      verify(avatarRepository, times(1)).findByUserId(userId);
+    }
+  }
+}


### PR DESCRIPTION
When trying to upload avatar, getting response 403 NotAuthorized

changes:
1. added new exception class online.talkandtravel.exception.avatar.UserAvatarNotFoundException
2. renamed and fixed method getAvatar
3. added test 